### PR TITLE
zero mask

### DIFF
--- a/examples/roberta/config/pretraining/zero_clap.yaml
+++ b/examples/roberta/config/pretraining/zero_clap.yaml
@@ -1,0 +1,51 @@
+# @package _group_
+common:
+  fp16: true
+  log_format: json
+  log_interval: 200
+
+checkpoint:
+  no_epoch_checkpoints: true
+
+task:
+  _name: masked_lm
+  data: ???
+  sample_break_mode: complete
+  tokens_per_sample: 512
+  omit_mask_and_pad: true
+  omit_unk: true
+
+criterion: masked_lm
+
+dataset:
+  batch_size: 16
+  ignore_unused_valid_subsets: true
+
+optimizer:
+  _name: adam
+  weight_decay: 0.01
+  adam_betas: (0.9,0.98)
+  adam_eps: 1e-06
+
+lr_scheduler:
+  _name: polynomial_decay
+  warmup_updates: 10000
+
+optimization:
+  clip_norm: 0
+  lr: [0.0005]
+  max_update: 125000
+  update_freq: [16]
+
+model:
+  _name: roberta
+  max_positions: 512
+  dropout: 0.
+  attention_dropout: 0.
+  no_token_positional_embeddings: true
+  encoder_alibi: true
+  encoder_alibi_asymmetrical: true
+  layernorm_embedding: false
+  contrastive_pretraining: true
+  initial_beta: 1.
+  zero_masking: true

--- a/examples/roberta/config/pretraining/zero_clap_attention_dropout.yaml
+++ b/examples/roberta/config/pretraining/zero_clap_attention_dropout.yaml
@@ -1,0 +1,51 @@
+# @package _group_
+common:
+  fp16: true
+  log_format: json
+  log_interval: 200
+
+checkpoint:
+  no_epoch_checkpoints: true
+
+task:
+  _name: masked_lm
+  data: ???
+  sample_break_mode: complete
+  tokens_per_sample: 512
+  omit_mask_and_pad: true
+  omit_unk: true
+
+criterion: masked_lm
+
+dataset:
+  batch_size: 16
+  ignore_unused_valid_subsets: true
+
+optimizer:
+  _name: adam
+  weight_decay: 0.01
+  adam_betas: (0.9,0.98)
+  adam_eps: 1e-06
+
+lr_scheduler:
+  _name: polynomial_decay
+  warmup_updates: 10000
+
+optimization:
+  clip_norm: 0
+  lr: [0.0005]
+  max_update: 125000
+  update_freq: [16]
+
+model:
+  _name: roberta
+  max_positions: 512
+  dropout: 0.
+  attention_dropout: 0.1
+  no_token_positional_embeddings: true
+  encoder_alibi: true
+  encoder_alibi_asymmetrical: true
+  layernorm_embedding: false
+  contrastive_pretraining: true
+  initial_beta: 1.
+  zero_masking: true

--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -32,9 +32,11 @@ class Dictionary:
         self.count = []
         self.indices = {}
         self.bos_index = self.add_symbol(bos)
-        self.pad_index = self.add_symbol(pad)
+        if pad is not None:
+            self.pad_index = self.add_symbol(pad)
         self.eos_index = self.add_symbol(eos)
-        self.unk_index = self.add_symbol(unk)
+        if unk is not None:
+            self.unk_index = self.add_symbol(unk)
         if extra_special_symbols:
             for s in extra_special_symbols:
                 self.add_symbol(s)
@@ -202,7 +204,7 @@ class Dictionary:
 
     def pad(self):
         """Helper to get index of pad symbol"""
-        return self.pad_index
+        return self.pad_index if self.pad_word is not None else len(self)
 
     def eos(self):
         """Helper to get index of end-of-sentence symbol"""
@@ -213,7 +215,7 @@ class Dictionary:
         return self.unk_index
 
     @classmethod
-    def load(cls, f):
+    def load(cls, f, **omit_kwargs):
         """Loads the dictionary from a text file with the format:
 
         ```
@@ -222,7 +224,7 @@ class Dictionary:
         ...
         ```
         """
-        d = cls()
+        d = cls(**omit_kwargs)
         d.add_from_file(f)
         return d
 


### PR DESCRIPTION
option to zero out the input embedding instead of using a trainable
<mask> embedding by re-arranging dictionary.pad() & mask index and
using src_tokens.clamp().

TODO: fill_mask() won't work yet
