### PR TITLE
exp with high initial concentration, syntax fix

### DIFF
--- a/examples/roberta/config/pretraining/s_vae_high_init.yaml
+++ b/examples/roberta/config/pretraining/s_vae_high_init.yaml
@@ -1,0 +1,55 @@
+# @package _group_
+common:
+  fp16: false
+  log_format: json
+  log_interval: 200
+
+checkpoint:
+  no_epoch_checkpoints: true
+
+task:
+  _name: masked_lm
+  data: ???
+  sample_break_mode: complete
+  tokens_per_sample: 512
+  omit_mask_and_pad: true
+  omit_unk: true
+  mask_prob: 0.0
+
+criterion: masked_lm
+
+dataset:
+  batch_size: 8
+  ignore_unused_valid_subsets: true
+
+optimizer:
+  _name: adam
+  weight_decay: 0.01
+  adam_betas: (0.9,0.98)
+  adam_eps: 1e-06
+
+lr_scheduler:
+  _name: polynomial_decay
+  warmup_updates: 10000
+
+optimization:
+  clip_norm: 0
+  lr: [0.0005]
+  max_update: 125000
+  update_freq: [32]
+
+model:
+  _name: roberta
+  max_positions: 512
+  dropout: 0.
+  attention_dropout: 0.
+  no_token_positional_embeddings: true
+  encoder_alibi: true
+  encoder_alibi_asymmetrical: true
+  layernorm_embedding: false
+  contrastive_pretraining: true
+  initial_beta: 1.
+  zero_masking: true
+  mask_prob: 0.15
+  vae_beta: 1.
+  initial_scale: 100.

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -125,7 +125,7 @@ def main(cfg: FairseqConfig) -> None:
 
     # Something is resetting the parameters and I don't know what :(
     # So, I am forced to put this here.
-    if hasattr(model.encoder, "scales")
+    if hasattr(model.encoder, "scales"):
         model.encoder.scales.reset_parameters()
 
     # Load valid dataset (we load training data below, based on the latest checkpoint)


### PR DESCRIPTION
It turned out that high init. concentration alone is enough to avoid posterior
collapse. In fact, since the derivative of the KL divergence between von Mises-Fisher
/ power spherical distribution and hyperspherical uniform distribution w.r.t.
direction is 0, it's probably easier for S-VAE to avoid posterior collapse.
