### PR TITLE
[fairseq] Guard call to `shape_as_tensor` with `is_in_onnx_export()` …

### DIFF
--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -65,7 +65,12 @@ class SinusoidalPositionalEmbedding(nn.Module):
         positions: Optional[Any] = None,
     ):
         """Input is expected to be of size [bsz x seqlen]."""
-        bspair = torch.onnx.operators.shape_as_tensor(input)
+        if torch.jit.is_scripting():
+            bspair = torch.onnx.operators.shape_as_tensor(input)
+        elif torch.onnx.is_in_onnx_export():
+            bspair = torch.onnx.operators.shape_as_tensor(input)
+        else:
+            bspair = input.size()
         bsz, seq_len = bspair[0], bspair[1]
         max_pos = self.padding_idx + 1 + seq_len
         if self.weights is None or max_pos > self.weights.size(0):


### PR DESCRIPTION
…(#4708)

This is a no-op in eager and in ONNX export, but it's better for other tracers if this is preserved as shapes directly instead of converted to a tensor.

There is a little annoying code duplication with
`torch.jit.is_scripting()`, which is unforunately necessary because we didn't implement compile-time short circuiting correctly in TorchScript lol.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (issue).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
