### PR TITLE
final configs and clean-up

### DIFF
--- a/examples/roberta/config/pretraining/baseline_pile.yaml
+++ b/examples/roberta/config/pretraining/baseline_pile.yaml
@@ -2,22 +2,23 @@
 common:
   fp16: true
   log_format: json
-  log_interval: 10
+  log_interval: 500
 
 checkpoint:
   no_epoch_checkpoints: true
-  save_interval_updates: 10000
+  save_interval_updates: 5000
 
 task:
   _name: masked_lm
   data: ???
   sample_break_mode: complete
   tokens_per_sample: 2048
+  shorten_method: truncate
 
 criterion: masked_lm
 
 dataset:
-  batch_size: 1
+  batch_size: 4
   ignore_unused_valid_subsets: true
 
 optimizer:
@@ -27,19 +28,19 @@ optimizer:
   adam_eps: 1e-06
 
 lr_scheduler:
-  _name: polynomial_decay
+  _name: cosine
   warmup_updates: 10000
+  lr_period_updates: 146390
+  lr_shrink: 1.0
+  min_lr: 0.00006
 
 optimization:
   clip_norm: 0
   lr: [0.0006]
-  max_update: 1000000
+  max_update: 133082
   max_epoch: 1
   update_freq: [16]
 
 model:
   _name: roberta
   max_positions: 2048
-  dropout: 0.1
-  attention_dropout: 0.1
-  encoder_learned_pos: false

--- a/examples/roberta/config/pretraining/zero_clap_pile.yaml
+++ b/examples/roberta/config/pretraining/zero_clap_pile.yaml
@@ -2,11 +2,11 @@
 common:
   fp16: true
   log_format: json
-  log_interval: 10
+  log_interval: 500
 
 checkpoint:
   no_epoch_checkpoints: true
-  save_interval_updates: 10000
+  save_interval_updates: 5000
 
 task:
   _name: masked_lm
@@ -15,11 +15,12 @@ task:
   tokens_per_sample: 2048
   omit_mask_and_pad: true
   omit_unk: true
+  shorten_method: truncate
 
 criterion: masked_lm
 
 dataset:
-  batch_size: 1
+  batch_size: 4
   ignore_unused_valid_subsets: true
 
 optimizer:
@@ -29,13 +30,16 @@ optimizer:
   adam_eps: 1e-06
 
 lr_scheduler:
-  _name: polynomial_decay
+  _name: cosine
   warmup_updates: 10000
+  lr_period_updates: 146390
+  lr_shrink: 1.0
+  min_lr: 0.00006
 
 optimization:
   clip_norm: 0
   lr: [0.0006]
-  max_update: 1000000
+  max_update: 133082
   max_epoch: 1
   update_freq: [16]
 
@@ -51,3 +55,4 @@ model:
   contrastive_pretraining: true
   initial_beta: 1.
   zero_masking: true
+  no_scale_embedding: false

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -123,11 +123,6 @@ def main(cfg: FairseqConfig) -> None:
         )
     )
 
-    # Something is resetting the parameters and I don't know what :(
-    # So, I am forced to put this here.
-    if hasattr(model.encoder, "scales"):
-        model.encoder.scales.reset_parameters()
-
     # Load valid dataset (we load training data below, based on the latest checkpoint)
     # We load the valid dataset AFTER building the model
     data_utils.raise_if_valid_subsets_unintentionally_ignored(cfg)


### PR DESCRIPTION
Extremely long training sequences seem to somehow slip through. `shorten_method: truncate` to get around these.