### PR TITLE
fix special token bug

### DIFF
--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -32,11 +32,9 @@ class Dictionary:
         self.count = []
         self.indices = {}
         self.bos_index = self.add_symbol(bos)
-        if pad is not None:
-            self.pad_index = self.add_symbol(pad)
+        self.pad_index = self.add_symbol(pad)
         self.eos_index = self.add_symbol(eos)
-        if unk is not None:
-            self.unk_index = self.add_symbol(unk)
+        self.unk_index = self.add_symbol(unk)
         if extra_special_symbols:
             for s in extra_special_symbols:
                 self.add_symbol(s)
@@ -204,7 +202,7 @@ class Dictionary:
 
     def pad(self):
         """Helper to get index of pad symbol"""
-        return getattr(self, "pad_index", len(self))
+        return self.pad_index
 
     def eos(self):
         """Helper to get index of end-of-sentence symbol"""
@@ -212,10 +210,10 @@ class Dictionary:
 
     def unk(self):
         """Helper to get index of unk symbol"""
-        return getattr(self, "unk_index", None)
+        return self.unk_index
 
     @classmethod
-    def load(cls, f, **omit_kwargs):
+    def load(cls, f):
         """Loads the dictionary from a text file with the format:
 
         ```
@@ -224,7 +222,7 @@ class Dictionary:
         ...
         ```
         """
-        d = cls(**omit_kwargs)
+        d = cls()
         d.add_from_file(f)
         return d
 

--- a/fairseq/tasks/masked_lm.py
+++ b/fairseq/tasks/masked_lm.py
@@ -110,14 +110,14 @@ class MaskedLMConfig(FairseqDataclass):
     omit_mask_and_pad: bool = field(
         default=False,
         metadata={
-            "help": "omit <mask> and <pad> from the dictionary and use placeholder indices instead."
+            "help": "omit <mask> from the dictionary."
         },
     )
 
     omit_unk: bool = field(
         default=False,
         metadata={
-            "help": "omit <unk> from the dictionary. This should only be used when <unk> isn't expected."
+            "help": "defunct and now has no effect."
         },
     )
 
@@ -134,7 +134,7 @@ class MaskedLMTask(FairseqTask):
         self.dictionary = dictionary
 
         if cfg.omit_mask_and_pad:
-            self.mask_idx = len(dictionary) + 1
+            self.mask_idx = len(dictionary)
         else:
             # add mask token
             self.mask_idx = dictionary.add_symbol("<mask>")
@@ -143,12 +143,7 @@ class MaskedLMTask(FairseqTask):
     def setup_task(cls, cfg: MaskedLMConfig, **kwargs):
         paths = utils.split_paths(cfg.data)
         assert len(paths) > 0
-        omit_kwargs = {}
-        if cfg.omit_mask_and_pad:
-            omit_kwargs['pad'] = None
-        if cfg.omit_unk:
-            omit_kwargs['unk'] = None
-        dictionary = Dictionary.load(os.path.join(paths[0], "dict.txt"), **omit_kwargs)
+        dictionary = Dictionary.load(os.path.join(paths[0], "dict.txt"))
         logger.info("dictionary: {} types".format(len(dictionary)))
         return cls(cfg, dictionary)
 


### PR DESCRIPTION
Big 4 special tokens (`<s>, <pad>, </s>, <unk>`) are hard-coded during the preprocessing step and attempt to remove <pad> and <unk> in https://github.com/EIFY/fairseq/pull/5 resulted in a bug. The net effect is that the model only has 50262 embeddings instead of 50264. Fortunately, the last 4 lines of `dict.txt` is 
```
50256 0
madeupword0000 0
madeupword0001 0
madeupword0002 0
```
So after this fix all we have to do is to remove `madeupword0001` and `madeupword0002` in order to load a pretrained model.
~~I though in addition the index of `</s>` also has to be fixed but so far there has been no effect.~~